### PR TITLE
Return inherited type

### DIFF
--- a/test/test_jewish_calendar.py
+++ b/test/test_jewish_calendar.py
@@ -5,7 +5,6 @@ from dateutil import tz, parser
 
 import test.test_helper
 from zmanim.hebrew_calendar.jewish_calendar import JewishCalendar
-from zmanim.hebrew_calendar.jewish_date import JewishDate
 
 
 class TestJewishCalendar(unittest.TestCase):
@@ -900,9 +899,3 @@ class TestJewishCalendar(unittest.TestCase):
         expected_time = first_molad + timedelta(microseconds=expected_offset)
         # round for floating microsecond precision inconsistency
         self.assertEqual(calendar.sof_zman_kiddush_levana_between_moldos().toordinal(), expected_time.toordinal())
-
-    def test_date_arithmetic_returns_inherited_type(self):
-        for instance, type in [(JewishCalendar(5783, 1, 1), JewishCalendar), (JewishDate(5783, 1, 1), JewishDate)]:
-            self.assertIsInstance(instance, type)
-            instance += timedelta(days=1)
-            self.assertIsInstance(instance, type)

--- a/test/test_jewish_calendar.py
+++ b/test/test_jewish_calendar.py
@@ -5,6 +5,7 @@ from dateutil import tz, parser
 
 import test.test_helper
 from zmanim.hebrew_calendar.jewish_calendar import JewishCalendar
+from zmanim.hebrew_calendar.jewish_date import JewishDate
 
 
 class TestJewishCalendar(unittest.TestCase):
@@ -899,3 +900,9 @@ class TestJewishCalendar(unittest.TestCase):
         expected_time = first_molad + timedelta(microseconds=expected_offset)
         # round for floating microsecond precision inconsistency
         self.assertEqual(calendar.sof_zman_kiddush_levana_between_moldos().toordinal(), expected_time.toordinal())
+
+    def test_date_arithmetic_returns_inherited_type(self):
+        for instance, type in [(JewishCalendar(5783, 1, 1), JewishCalendar), (JewishDate(5783, 1, 1), JewishDate)]:
+            self.assertIsInstance(instance, type)
+            instance += timedelta(days=1)
+            self.assertIsInstance(instance, type)

--- a/test/test_jewish_date.py
+++ b/test/test_jewish_date.py
@@ -649,3 +649,12 @@ class TestJewishDate(unittest.TestCase):
         self.assertEqual(subject.jewish_month_name(), 'sivan')
         subject.jewish_month = 8
         self.assertEqual(subject.jewish_month_name(), 'cheshvan')
+
+    def test_date_arithmetic_returns_inherited_type(self):
+        class JewishDateChild(JewishDate):
+            pass
+
+        for instance, type in [(JewishDateChild(5783, 1, 1), JewishDateChild), (JewishDate(5783, 1, 1), JewishDate)]:
+            self.assertIsInstance(instance, type)
+            instance += timedelta(days=1)
+            self.assertIsInstance(instance, type)

--- a/zmanim/hebrew_calendar/jewish_date.py
+++ b/zmanim/hebrew_calendar/jewish_date.py
@@ -227,14 +227,14 @@ class JewishDate:
         if isinstance(addend, int):
             return copy.copy(self).forward(addend)
         elif isinstance(addend, timedelta):
-            return JewishDate(self.gregorian_date + addend)
+            return type(self)(self.gregorian_date + addend)
         raise ValueError
 
     def __sub__(self, subtrahend):
         if isinstance(subtrahend, int):
             return copy.copy(self).back(subtrahend)
         elif isinstance(subtrahend, timedelta):
-            return JewishDate(self.gregorian_date - subtrahend)
+            return type(self)(self.gregorian_date - subtrahend)
         elif isinstance(subtrahend, JewishDate):
             return self.gregorian_date - subtrahend.gregorian_date
         elif isinstance(subtrahend, date):


### PR DESCRIPTION
Return an instance of the sub-classed `JewishDate` type when applying any of the base `JewishDate` methods (`__add__` and `__sub__`).